### PR TITLE
point 동시성 해결을 위해서 비관적락을 사용해서 동시성 테스트를 함

### DIFF
--- a/concert/concert/src/main/java/com/example/concert/Application/UserPointFacade.java
+++ b/concert/concert/src/main/java/com/example/concert/Application/UserPointFacade.java
@@ -6,34 +6,43 @@ import com.example.concert.domain.user.pointHistory.entity.PointHistory;
 import com.example.concert.domain.user.pointHistory.enumType.PointType;
 import com.example.concert.domain.user.pointHistory.service.PointHistoryService;
 import com.example.concert.domain.user.service.UserService;
+import com.example.concert.redis.LockService;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class UserPointFacade {
     // 사용자 포인트에 관한 서비스와 그에 대한 결과를 저장하기 위한  서비스를  application 계층에 Facade 로 둔다.
     private final UserService userService;
     private final PointHistoryService pointHistoryService;
 
+    private final LockService lockService;
+
     public User getUserPoint(Long userId){
         return userService.getUserPoint(userId);
     }
    //사용자의 포인트와 그 결과를 담기 위해서 Transactional 걸어서 메서드를 생성
-    @Transactional
+
     public PointHistory changePoint(PointRequest pointRequest) throws Exception {
+
         var history = PointHistory.builder().userId(pointRequest.getUserId()).amount(pointRequest.getCharge()).build();
         BigDecimal amount = pointRequest.getCharge();
         // 값을 확인하고 충전인지 사용인지를 확인하는  의 메서드
         history.checkType(amount);
        //userId 에 맞는 포인트를 가져와서 값을 계산하는 로직
-        var userPoint = getUserPoint(pointRequest.getUserId());
-        userPoint.calculate(amount);
-        //계산된 포인트를 저장하고 결과를  pointHistory 저장하는 로직
-        userService.save(userPoint);
+        userService.calculate(pointRequest.getUserId(), amount);
+
         return pointHistoryService.save(history);
     }
 }

--- a/concert/concert/src/main/java/com/example/concert/domain/concertSeat/entity/ConcertSeat.java
+++ b/concert/concert/src/main/java/com/example/concert/domain/concertSeat/entity/ConcertSeat.java
@@ -35,7 +35,8 @@ public class ConcertSeat extends BaseEntity {
     private SeatStatus seatStatus; //좌석 상태
     private Integer seatNo; //좌석 번호
     private BigDecimal price; //좌석 가격
-    
+    @Version    //낙관적 락을 위해 version정보 삽입
+    private int version;
 
     //객체 변환
     public static ConcertSeatResponse entityToResponse(ConcertSeat concertSeat){

--- a/concert/concert/src/main/java/com/example/concert/domain/concertSeat/entity/ConcertSeat.java
+++ b/concert/concert/src/main/java/com/example/concert/domain/concertSeat/entity/ConcertSeat.java
@@ -35,8 +35,9 @@ public class ConcertSeat extends BaseEntity {
     private SeatStatus seatStatus; //좌석 상태
     private Integer seatNo; //좌석 번호
     private BigDecimal price; //좌석 가격
+    
 
-   //객체 변환
+    //객체 변환
     public static ConcertSeatResponse entityToResponse(ConcertSeat concertSeat){
         return ConcertSeatResponse.builder()
                 .concertSeatId(concertSeat.getConcertSeatId())

--- a/concert/concert/src/main/java/com/example/concert/domain/concertSeat/service/service/SeatRepository.java
+++ b/concert/concert/src/main/java/com/example/concert/domain/concertSeat/service/service/SeatRepository.java
@@ -20,4 +20,6 @@ public interface SeatRepository {
     List<ConcertSeat> findTempSeatByUserId(Long userId);
 
     void updatedSeatToReserved(Long userId, List<Long> seatIds);
+
+    Integer updateSeat(ConcertSeat concertSeat);
 }

--- a/concert/concert/src/main/java/com/example/concert/domain/concertSeat/service/service/SeatService.java
+++ b/concert/concert/src/main/java/com/example/concert/domain/concertSeat/service/service/SeatService.java
@@ -59,13 +59,14 @@ public class SeatService {
         if(size == SEAT_LIMIT) throw new Exception("ALREAY FULL SEAT");
     }
 
+    //이번 과제의 핵심로직
     @Transactional
     public ConcertSeat reserveSeatTemp(ConcertSeatRequest concertSeatRequest) throws Exception {
-        Long userId = concertSeatRequest.getUserId();
+        Long userId = concertSeatRequest.getUserId(); 
         Long concertDetailId = concertSeatRequest.getConcertDetailId();
         int seatNo = concertSeatRequest.getSeatNo();
         if(seatNo<0 || seatNo>SEAT_LIMIT)throw new BusinessBaseException(ErrorCode.SEAT_NO_INVALID);
-        //유니크 제약 조건이걸린 콘서트 속성 과 좌석 번호를 가져와서
+        //사실상 유니크 제약조건 이 걸려있어서 Lock을 안걸어도된다고 허재코치님께서 말씀하셨지만, 좌석 조회에 비관적락을 거는 로직
         ConcertSeat concertSeat = seatRepository.findSeat(concertDetailId,concertSeatRequest.getSeatNo());
         //없는 좌석이면 새롭게 추가를 하고
         if(concertSeat==null){
@@ -77,13 +78,14 @@ public class SeatService {
                     .build();
             
             return seatRepository.createSeat(request);
-        } //있는 좌석이면 userId 랑 상태만 추가해서 사용한다.
+        } //있는 좌석이면 userId 랑 상태만 추가해서 업데이트한다.
         if(concertSeat.getSeatStatus() == SeatStatus.RESERVABLE){
             concertSeat.setSeatStatus(SeatStatus.TEMP);
             concertSeat.setUserId(userId);
             seatRepository.updateSeat(concertSeat);
             return concertSeat;
         }
+        //예약을 실패할 경우 아래를 탄다.
         throw new Exception("CAN'T SEAT TO RESERVE");
     }
 

--- a/concert/concert/src/main/java/com/example/concert/domain/concertSeat/service/service/SeatService.java
+++ b/concert/concert/src/main/java/com/example/concert/domain/concertSeat/service/service/SeatService.java
@@ -34,6 +34,7 @@ public class SeatService {
     @PersistenceContext
     private EntityManager entityManager;
 
+
     public List<ConcertSeat> FindAbleSeats(Long concertDetailId) throws Exception {
         List<ConcertSeat> reservedSeats = seatRepository.findStatusReserved(concertDetailId, SeatStatus.RESERVABLE);  //예약가능한 자리 빼고 불러오는 리스트
         checkSize(reservedSeats.size());  //예약된 자리의 크기를 검증하는 메서드
@@ -60,13 +61,15 @@ public class SeatService {
     }
 
     //이번 과제의 핵심로직
+    //재처리가 필요하다면 재처리 @Retryable로직을 넣었겠지만, 한번 누군가 좌석을 예약하면 재처리할 필요가 없기 때문에
+    //비관적 Lock보다는 낙관적 Lock을 통해서 해결결
     @Transactional
     public ConcertSeat reserveSeatTemp(ConcertSeatRequest concertSeatRequest) throws Exception {
         Long userId = concertSeatRequest.getUserId(); 
         Long concertDetailId = concertSeatRequest.getConcertDetailId();
         int seatNo = concertSeatRequest.getSeatNo();
         if(seatNo<0 || seatNo>SEAT_LIMIT)throw new BusinessBaseException(ErrorCode.SEAT_NO_INVALID);
-        //사실상 유니크 제약조건 이 걸려있어서 Lock을 안걸어도된다고 허재코치님께서 말씀하셨지만, 좌석 조회에 비관적락을 거는 로직
+        //사실상 유니크 제약조건 이 걸려있어서 Lock을 안걸어도된다고 허재코치님께서 말씀하셨지만 과제여서 추가
         ConcertSeat concertSeat = seatRepository.findSeat(concertDetailId,concertSeatRequest.getSeatNo());
         //없는 좌석이면 새롭게 추가를 하고
         if(concertSeat==null){

--- a/concert/concert/src/main/java/com/example/concert/domain/user/service/UserRepository.java
+++ b/concert/concert/src/main/java/com/example/concert/domain/user/service/UserRepository.java
@@ -7,8 +7,8 @@ public interface UserRepository {
     // 서비스에서 사용하는 기능들
 
     User getUserPoint(Long userId);
-
+    //유저의 포인트를 업데이트하는 메서드
     int updateUserPoint(User userPoint);
-
+     //포인트 조회에 비관적락 거는 메서드
     User getUserPointWithLock(Long userId);
 }

--- a/concert/concert/src/main/java/com/example/concert/domain/user/service/UserRepository.java
+++ b/concert/concert/src/main/java/com/example/concert/domain/user/service/UserRepository.java
@@ -3,7 +3,12 @@ package com.example.concert.domain.user.service;
 import com.example.concert.domain.user.entity.User;
 //유저 레파지토리 인터페이스 계층구조를 위해서 선언한후 도메인 계층에 올려둠
 public interface UserRepository {
-     User saveUser(User userPoint);
+    User saveUser(User userPoint);
     // 서비스에서 사용하는 기능들
+
     User getUserPoint(Long userId);
+
+    int updateUserPoint(User userPoint);
+
+    User getUserPointWithLock(Long userId);
 }

--- a/concert/concert/src/main/java/com/example/concert/domain/user/service/UserService.java
+++ b/concert/concert/src/main/java/com/example/concert/domain/user/service/UserService.java
@@ -3,18 +3,37 @@ package com.example.concert.domain.user.service;
 import com.example.concert.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+
    // 유저에 맞는 포인트를 가져오는 로직
-    public User getUserPoint(Long userId){
-        return  userRepository.getUserPoint(userId);
-    }
-   //유저를 저장하는 로직
+   public User getUserPoint(Long userId){
+       return  userRepository.getUserPoint(userId);
+   }
+
+    public User getUserWithLock(Long userId){return userRepository.getUserPointWithLock(userId);}
+    //유저를 저장하는 로직
     public User save(User userPoint) {
         return userRepository.saveUser(userPoint);
     }
+    public int updateUserPoint(User userPoint) {
+        return userRepository.updateUserPoint(userPoint);
+    }
+
+
+    @Transactional
+    public int calculate(Long userId, BigDecimal amount) throws Exception {
+        var userPoint = getUserWithLock(userId);
+        userPoint.calculate(amount);
+        //계산된 포인트를 저장하고 결과를  pointHistory 저장하는 로직
+        return updateUserPoint(userPoint);
+    }
+
 }
 

--- a/concert/concert/src/main/java/com/example/concert/domain/user/service/UserService.java
+++ b/concert/concert/src/main/java/com/example/concert/domain/user/service/UserService.java
@@ -16,7 +16,7 @@ public class UserService {
    public User getUserPoint(Long userId){
        return  userRepository.getUserPoint(userId);
    }
-
+    //이번 과제의 핵심 비관적 락을 거는 메서드  
     public User getUserWithLock(Long userId){return userRepository.getUserPointWithLock(userId);}
     //유저를 저장하는 로직
     public User save(User userPoint) {
@@ -26,12 +26,12 @@ public class UserService {
         return userRepository.updateUserPoint(userPoint);
     }
 
-
+    //가장 작은 단위로 유저를 조회하고 포인트를 변경하는 것을 트랜잭션으로 묶음
     @Transactional
     public int calculate(Long userId, BigDecimal amount) throws Exception {
         var userPoint = getUserWithLock(userId);
         userPoint.calculate(amount);
-        //계산된 포인트를 저장하고 결과를  pointHistory 저장하는 로직
+        //비관적락을 획득한 순서로 부터 순차로 업데이트
         return updateUserPoint(userPoint);
     }
 

--- a/concert/concert/src/main/java/com/example/concert/infrastructure/concert/seat/SeatJpaRepository.java
+++ b/concert/concert/src/main/java/com/example/concert/infrastructure/concert/seat/SeatJpaRepository.java
@@ -29,10 +29,9 @@ public interface SeatJpaRepository extends JpaRepository<ConcertSeat, Long> {
     List<ConcertSeat> findByUserIdAndSeatStatus(Long userId, SeatStatus temp);
 
     //유닉크키가 걸려있는 부분 들고오기
-    //비관적 락 사용 --> 하지만 Lock을 안걸어도 ConcertDetailId와 SeatId에 유니크 제약조건이 걸려있기때문에
+    //낙관적 락 사용 --> 하지만 Lock을 안걸어도 ConcertDetailId와 SeatId에 유니크 제약조건이 걸려있기때문에
+    //어짜피 한명만 통과하면 되기때문에 비관적 락을 걸필요 없음 락 획득 실패시 끝나느 로직
     //하나의 트렌젝션이 예약에 성공한다면 중복 에러로 동시성을 이미 처리했음
-    //있어도되고 없어도 되는 락임
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT c FROM ConcertSeat c Where c.concertDetailId = :concertDetailId AND c.seatNo = :seatNo")
     ConcertSeat findByConcertDetailIdAndSeatNo(Long concertDetailId, int seatNo);
 

--- a/concert/concert/src/main/java/com/example/concert/infrastructure/concert/seat/SeatRepositoryImpl.java
+++ b/concert/concert/src/main/java/com/example/concert/infrastructure/concert/seat/SeatRepositoryImpl.java
@@ -20,7 +20,7 @@ public class SeatRepositoryImpl implements SeatRepository {
     public List<ConcertSeat> findStatusReserved(Long concertDetailId, SeatStatus reserved) {
         return seatJpaRepository.findByConcertDetailIdAndSeatStatusNot(concertDetailId,reserved);
     }
-//2
+    //좌석을 예약하기전에 좌석을 조회하는 로직 -> 비관적 락 걸어도 되고 안걸어도된다 -> 낙관적 Lock은 효율이없기에 아예 배제
     @Override
     public ConcertSeat findSeat(Long concertDetailId,int seatNo) {
         return seatJpaRepository.findByConcertDetailIdAndSeatNo(concertDetailId,seatNo);
@@ -45,9 +45,15 @@ public class SeatRepositoryImpl implements SeatRepository {
     public List<ConcertSeat> findTempSeatByUserId(Long userId) {
         return seatJpaRepository.findByUserIdAndSeatStatus(userId,SeatStatus.TEMP);
     }
-//7
+//
     @Override
     public void updatedSeatToReserved(Long userId, List<Long> seatIds) {
         seatJpaRepository.updateSeatStatusAndUserId(SeatStatus.RESERVED,userId,seatIds);
+    }
+
+    //좌석을 업데이트하는 쿼리
+    @Override
+    public Integer updateSeat(ConcertSeat concertSeat) {
+        return seatJpaRepository.updateSeatStatusAndUserId(concertSeat.getUserId(),SeatStatus.TEMP,concertSeat.getSeatNo());
     }
 }

--- a/concert/concert/src/main/java/com/example/concert/infrastructure/user/UserJpaRepository.java
+++ b/concert/concert/src/main/java/com/example/concert/infrastructure/user/UserJpaRepository.java
@@ -1,8 +1,26 @@
 package com.example.concert.infrastructure.user;
 
 import com.example.concert.domain.user.entity.User;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
 //실제 구현체
 public interface UserJpaRepository extends JpaRepository<User,Long> {
 
+    //이 로직은 실패하면 안되는 로직이기 때문에 비관적락에 가장 잘 어울리고, 낙관적 락으로 재시도를 구현해서
+    //완벽하게 처리한다고 해도 비관적락 보다 훨씬 오래걸림을 알 수 있음 그래서 낙관적 락을 통해서 구현했음.
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select u from User u where u.userId = :userId")
+    Optional<User> findByIdWithLock(@Param("userId") Long userId);
+
+    @Modifying
+    @Query("update User u set u.point =:point where u.userId =:userId")
+    int updateUserPoint(@Param("userId") Long userId, @Param("point") BigDecimal point);
 }

--- a/concert/concert/src/main/java/com/example/concert/infrastructure/user/UserRepositoryImpl.java
+++ b/concert/concert/src/main/java/com/example/concert/infrastructure/user/UserRepositoryImpl.java
@@ -24,4 +24,14 @@ public class UserRepositoryImpl implements UserRepository {
     public User getUserPoint(Long userId) {
         return userJpaRepository.findById(userId).orElseThrow(()->new BusinessBaseException(ErrorCode.USER_NOT_FOUND));
     }
+
+    @Override
+    public User getUserPointWithLock(Long userId) {
+        return userJpaRepository.findByIdWithLock(userId).orElseThrow(()->new BusinessBaseException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    @Override
+    public int updateUserPoint(User userPoint) {
+        return userJpaRepository.updateUserPoint(userPoint.getUserId(),userPoint.getPoint());
+    }
 }

--- a/concert/concert/src/test/java/com/example/concert/currency/ConcertSeatServiceTest.java
+++ b/concert/concert/src/test/java/com/example/concert/currency/ConcertSeatServiceTest.java
@@ -5,38 +5,59 @@ import com.example.concert.domain.concertSeat.entity.ConcertSeat;
 import com.example.concert.domain.concertSeat.entity.SeatStatus;
 import com.example.concert.domain.concertSeat.service.service.SeatRepository;
 import com.example.concert.domain.concertSeat.service.service.SeatService;
+import com.example.concert.infrastructure.concert.seat.SeatJpaRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 @SpringBootTest
+@EnableRetry
 public class ConcertSeatServiceTest {
     //10개의 쓰레드를 사용해서 동시성을 테스트하는 코드
     @Autowired
     private SeatService concertSeatService;
 
+
     @Autowired
-    private SeatRepository seatRepository;
+    private SeatJpaRepository seatRepository;
 
-    private static final int THREAD_COUNT = 10;
-
+    private static final int THREAD_COUNT = 100;
+    //비관적 Lock은 insert에 존재하지 않음으로. 좌석이 있다는 가정하에 비관적락 테스트
+   @BeforeEach
+    void before(){
+        seatRepository.save(ConcertSeat.builder().concertDetailId(1L).concertSeatId(1L).seatNo(1).version(1).seatStatus(SeatStatus.RESERVABLE).build());
+    }
     @Test
+    @DisplayName("이미 좌석이 예약되어있는경우 비관적Lock으로 조회하고 update로직을 실행하여 한 트랜잭션이 성공하면 아래는 모두 update를 실패한다.")
     public void testConcurrentSeatReservation() throws InterruptedException {
         ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
         CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
         Long concertDetailId = 1L;
         int seatNo = 1;
-
+        long startTime = System.currentTimeMillis();
         for (int i = 0; i < THREAD_COUNT; i++) {
             Long userId = (long) i + 1;
             executorService.submit(() -> {
                 try {
                     ConcertSeatRequest request = new ConcertSeatRequest(userId, concertDetailId, seatNo);
-                    concertSeatService.reserveSeatTemp(request);
-                } catch (Exception e) {
+                    var result = concertSeatService.reserveSeatTemp(request);
+                    System.out.println(result.getSeatStatus());
+                    System.out.println(result.getUserId());
+                    System.out.println(result.getSeatNo());
+                }catch (OptimisticLockingFailureException e){
+                    System.out.println("낙관적락에 걸림");
+                }
+                catch (Exception e) {
                     System.out.println("Exception: " + e.getMessage());
                 } finally {
                     latch.countDown();
@@ -47,6 +68,38 @@ public class ConcertSeatServiceTest {
         latch.await();
         executorService.shutdown();
 
-        ConcertSeat reservedSeat = seatRepository.findSeat(concertDetailId, seatNo);
+
+        long endTime = System.currentTimeMillis(); // 종료 시간 측정
+        System.out.println("Execution time: " + (endTime - startTime) + " ms"); // 실행 시간 출력
+    }
+
+    @DisplayName("[좌석이 없는 경우] - 동시에 여러명이 한 좌석을 예약하는 경우 1명만 예약이 되어야 한다.")
+    @Test
+    void test_temporaryReservationSeat_notRow() throws InterruptedException {
+        // Given
+        Long concertDetailId = 2L;
+        int seatNo = 1;
+
+        // When
+        int numberOfRequest = 10;
+        CountDownLatch latch = new CountDownLatch(numberOfRequest);
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfRequest);
+
+        for(int i = 0; i < numberOfRequest; i++){
+            Long userId = (long) i;
+            executorService.submit(() -> {
+                try {
+                    ConcertSeatRequest request = new ConcertSeatRequest(userId, concertDetailId, seatNo);
+                    concertSeatService.reserveSeatTemp(request);
+                } catch (Exception e){
+
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+
     }
 }

--- a/concert/concert/src/test/java/com/example/concert/currency/ConcertSeatServiceTest.java
+++ b/concert/concert/src/test/java/com/example/concert/currency/ConcertSeatServiceTest.java
@@ -37,7 +37,7 @@ public class ConcertSeatServiceTest {
     void before(){
         seatRepository.save(ConcertSeat.builder().concertDetailId(1L).concertSeatId(1L).seatNo(1).version(1).seatStatus(SeatStatus.RESERVABLE).build());
     }
-    @Test
+       @Test
     @DisplayName("이미 좌석이 예약되어있는경우 비관적Lock으로 조회하고 update로직을 실행하여 한 트랜잭션이 성공하면 아래는 모두 update를 실패한다.")
     public void testConcurrentSeatReservation() throws InterruptedException {
         ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
@@ -54,25 +54,23 @@ public class ConcertSeatServiceTest {
                     System.out.println(result.getSeatStatus());
                     System.out.println(result.getUserId());
                     System.out.println(result.getSeatNo());
-                }catch (OptimisticLockingFailureException e){
+                } catch (OptimisticLockingFailureException e) {
                     System.out.println("낙관적락에 걸림");
-                }
-                catch (Exception e) {
+                } catch (Exception e) {
                     System.out.println("Exception: " + e.getMessage());
                 } finally {
                     latch.countDown();
                 }
             });
         }
+                latch.await();
+                executorService.shutdown();
+                long endTime = System.currentTimeMillis(); // 종료 시간 측정
+                System.out.println("Execution time: " + (endTime - startTime) + " ms"); // 실행 시간 출력
 
-        latch.await();
-        executorService.shutdown();
+            }
 
-
-        long endTime = System.currentTimeMillis(); // 종료 시간 측정
-        System.out.println("Execution time: " + (endTime - startTime) + " ms"); // 실행 시간 출력
-    }
-
+}
     @DisplayName("[좌석이 없는 경우] - 동시에 여러명이 한 좌석을 예약하는 경우 1명만 예약이 되어야 한다.")
     @Test
     void test_temporaryReservationSeat_notRow() throws InterruptedException {

--- a/concert/concert/src/test/java/com/example/concert/currency/UserPointCurrencyTest.java
+++ b/concert/concert/src/test/java/com/example/concert/currency/UserPointCurrencyTest.java
@@ -1,0 +1,67 @@
+package com.example.concert.currency;
+
+import com.example.concert.Application.UserPointFacade;
+import com.example.concert.Presentation.point.model.PointRequest;
+import com.example.concert.domain.user.entity.User;
+import com.example.concert.domain.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.retry.annotation.EnableRetry;
+
+import java.math.BigDecimal;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@SpringBootTest
+@EnableRetry
+public class UserPointCurrencyTest {
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserPointFacade userPointFacade;
+
+    private static final int THREAD_COUNT = 10;
+
+    @BeforeEach
+    void beforeEach() throws Exception {
+        userService.save(new User(1L,"taehwan",new BigDecimal(1000)));
+    }
+
+    @Test
+    @DisplayName("쓰레드를 10개놓고 같은 userId에 동시에 5000원을 충전했을때 51000원이 나오는 로직")
+    public void testConcurrentSeatReservation() throws InterruptedException {
+        System.out.println(userService.getUserPoint(1L).getName());
+        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+        CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+        int random = new Random().nextInt(10000);
+
+        long startTime = System.currentTimeMillis();
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            executorService.submit(() -> {
+                try {
+                    userPointFacade.changePoint(new PointRequest(1L,new BigDecimal(5000)));
+                } catch (OptimisticLockingFailureException e){//낙관적 락을 사용했을 때 로직
+                    System.out.println("여기걸림");
+                } catch (Exception e) {
+                    System.out.println("Exception: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+        System.out.println(userService.getUserPoint(1L).getPoint());
+
+        long endTime = System.currentTimeMillis(); // 종료 시간 측정
+        System.out.println("Execution time: " + (endTime - startTime) + " ms"); // 실행 시간 출력
+    }
+}


### PR DESCRIPTION
파일이 push가 잘못되어 수정이있어서 난잡한 점 죄송합니다 ..
Merge branch는 뛰어넘으셔도됩니다.
제가 실수로 파일을 다른걸 올려서

과제는
 Point -> 비관적락 -> 첫번째에 올리신걸로 보시면 될것같고, 지금 두번째에 올라간 Seat는 제가 실수로 비관적락으로 처리해서
 마지막에 올린 update된 부분에 재처리없는 낙관적락 코드를 봐주시면 감사할것 같습니다!!
실수를 해버렸네요 ㅜㅜ


1. 가장 작은 트랜잭션 단위로 묶었다고 생각했는데 트랜잭션을 어디에다 거는게 맞는 것인지

2. 현재 로직이 좌석이없으면 처음 예약하는사람아이디와 스테이트를 바꿔주고
만약 결제를 안했다면 스케줄러를통해서 유저아이디와 스테이트를 원상복귀해주는
로직인데 update는 애초에 seat상태가 예약가능한 상태일때만 update가 가능하고,
유니크 제약조건이 걸려있어서 애초에 락이없어도 가능한상태라, update부분에 집중을 걸어서 테스트했습니다

